### PR TITLE
Update hmac-sha512.c

### DIFF
--- a/lib/hmac-sha512.c
+++ b/lib/hmac-sha512.c
@@ -49,7 +49,7 @@ hmac_sha512 (const void *key, size_t keylen,
       sha512_finish_ctx (&keyhash, optkeybuf);
 
       key = optkeybuf;
-      keylen = 128;
+      keylen = 64;
     }
 
   /* Compute INNERHASH from KEY and IN.  */


### PR DESCRIPTION
modify hmac-sha512.c line 52, value from 128 to 64. Because after sha512, the length is 64.