### PR TITLE
mountlist: Consider GPFS filesystem as remote

### DIFF
--- a/lib/mountlist.c
+++ b/lib/mountlist.c
@@ -224,7 +224,7 @@ me_remote (char const *fs_name, char const *fs_type _GL_UNUSED)
 #ifndef ME_REMOTE
 /* A file system is "remote" if its Fs_name contains a ':'
    or if (it is of type (smbfs or cifs) and its Fs_name starts with '//')
-   or if it is of type (afs or auristorfs)
+   or if it is of type (afs, auristorfs or gpfs)
    or Fs_name is equal to "-hosts" (used by autofs to mount remote fs).  */
 # define ME_REMOTE(Fs_name, Fs_type)            \
     (strchr (Fs_name, ':') != NULL              \
@@ -235,6 +235,7 @@ me_remote (char const *fs_name, char const *fs_type _GL_UNUSED)
              || strcmp (Fs_type, "cifs") == 0)) \
      || strcmp (Fs_type, "afs") == 0            \
      || strcmp (Fs_type, "auristorfs") == 0     \
+     || strcmp (Fs_type, "gpfs") == 0     \
      || strcmp ("-hosts", Fs_name) == 0)
 #endif
 


### PR DESCRIPTION
Extending 7a15069b6 and adding the GPFS filesystem to
the list of remote filesystem.

Signed-off-by: Swen Schillig <swen@linux.ibm.com>