### PR TITLE
mountlist.c: Define fuse.portal mounts as dummy

### DIFF
--- a/lib/mountlist.c
+++ b/lib/mountlist.c
@@ -164,7 +164,10 @@
 
 #define ME_DUMMY_0(Fs_name, Fs_type)            \
   (strcmp (Fs_type, "autofs") == 0              \
+   || strcmp (Fs_type, "devtmpfs") == 0         \
+   || strcmp (Fs_type, "fuse.portal") == 0      \   
    || strcmp (Fs_type, "proc") == 0             \
+   || strcmp (Fs_type, "squashfs") == 0         \
    || strcmp (Fs_type, "subfs") == 0            \
    /* for Linux 2.6/3.x */                      \
    || strcmp (Fs_type, "debugfs") == 0          \


### PR DESCRIPTION
This corrects a problem that affects users with fuse.portal mounts, such as users who have installed Flatpak.
Running 'df' as user (not root) causes an error message:
"df: /run/user/1000/doc: Operation not permitted".
This is a significant problem for users who depend on df not returning an error exit code in their scripts.
The changes I have made to mountlist.c have been implemented in the Ubuntu Hirsute 21.04 package: coreutils 8.32-4ubuntu2 by using a patch.  It would be good to implement the change upstream in the master branch source code (git://git.sv.gnu.org/gnulib.git). 
The reasons for the change are detailed in: https://bugs.launchpad.net/ubuntu/+source/xdg-desktop-portal/+bug/1905623  by Julian Andres Klode <juliank@ubuntu.com>.  The bug report he posed said:
"/run/user/1000/doc is a fuse.portal mount point, but statfs() return EPERM, hence df produces an error message. Maybe statfs() is not implemented, but it would be good to quieten this down (df even does not allow me to ignore it, probably because it looks at statfs to find out fs type, so my fs type ignoring doesn't work)."
This problem has also been reported on Fedora 32 here: https://github.com/flatpak/xdg-desktop-portal/issues/512