### PR TITLE
add 2 files

### DIFF
--- a/modules/error-h
+++ b/modules/error-h
@@ -4,6 +4,8 @@ Functions for error reporting.
 Files:
 lib/error.in.h
 m4/error_h.m4
+m4/include_next.m4
+m4/absolute-header.m4
 
 Depends-on:
 gen-header


### PR DESCRIPTION
I executed the following on Rocky9 Linux.

`./gnulib-tool --create-megatestdir --with-tests --dir=$HOME/my/gnulib-bin error-h`

I received the following error message

```
executing aclocal -I glm4
executing autoconf
configure:4438: error: possibly undefined macro: gl_CHECK_NEXT_HEADERS
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
```

To resolve this, I added two lines to the file "modules/error-h".