### PR TITLE
lib: align structures for 64-bit platforms

### DIFF
--- a/lib/argp-help.c
+++ b/lib/argp-help.c
@@ -372,16 +372,16 @@ struct hol_entry
      probably been shadowed by some other entry).  */
   char *short_options;
 
-  /* Entries are sorted by their group first, in the order:
-       0, 1, 2, ..., n, -m, ..., -2, -1
-     and then alphabetically within each group.  The default is 0.  */
-  int group;
-
   /* The cluster of options this entry belongs to, or NULL if none.  */
   struct hol_cluster *cluster;
 
   /* The argp from which this option came.  */
   const struct argp *argp;
+
+  /* Entries are sorted by their group first, in the order:
+       0, 1, 2, ..., n, -m, ..., -2, -1
+     and then alphabetically within each group.  The default is 0.  */
+  int group;
 
   /* Position in the array */
   unsigned ord;

--- a/lib/argp-parse.c
+++ b/lib/argp-parse.c
@@ -77,13 +77,13 @@ static volatile int _argp_hang;
 
 static const struct argp_option argp_default_options[] =
 {
-  {"help",        '?',          NULL, 0,  N_("give this help list"), -1},
-  {"usage",       OPT_USAGE,    NULL, 0,  N_("give a short usage message"), 0},
-  {"program-name",OPT_PROGNAME, N_("NAME"), OPTION_HIDDEN,
+  {"help",          NULL,       '?', 0,  N_("give this help list"), -1},
+  {"usage",         NULL,       OPT_USAGE, 0,  N_("give a short usage message"), 0},
+  {"program-name",  N_("NAME"), OPT_PROGNAME, OPTION_HIDDEN,
    N_("set the program name"), 0},
-  {"HANG",        OPT_HANG,    N_("SECS"), OPTION_ARG_OPTIONAL | OPTION_HIDDEN,
+  {"HANG",          N_("SECS"), OPT_HANG, OPTION_ARG_OPTIONAL | OPTION_HIDDEN,
    N_("hang for SECS seconds (default 3600)"), 0},
-  {NULL, 0, NULL, 0, NULL, 0}
+  {NULL, NULL, 0, 0, NULL, 0}
 };
 
 static error_t
@@ -139,8 +139,8 @@ static const struct argp argp_default_argp =
 
 static const struct argp_option argp_version_options[] =
 {
-  {"version",     'V',          NULL, 0,  N_("print program version"), -1},
-  {NULL, 0, NULL, 0, NULL, 0}
+  {"version", NULL,   'V', 0,  N_("print program version"), -1},
+  {NULL, NULL, 0, 0, NULL, 0}
 };
 
 static error_t

--- a/lib/argp.h
+++ b/lib/argp.h
@@ -77,13 +77,13 @@ struct argp_option
      can use following options with the OPTION_ALIAS flag set.  */
   const char *name;
 
-  /* What key is returned for this option.  If > 0 and printable, then it's
-     also accepted as a short option.  */
-  int key;
-
   /* If non-NULL, this is the name of the argument associated with this
      option, which is required unless the OPTION_ARG_OPTIONAL flag is set. */
   const char *arg;
+
+  /* What key is returned for this option.  If > 0 and printable, then it's
+     also accepted as a short option.  */
+  int key;
 
   /* OPTION_ flags.  */
   int flags;
@@ -291,14 +291,14 @@ struct argp_child
   /* The child parser.  */
   const struct argp *argp;
 
-  /* Flags for this child.  */
-  int flags;
-
   /* If non-zero, an optional header to be printed in help output before the
      child options.  As a side-effect, a non-zero value forces the child
      options to be grouped together; to achieve this effect without actually
      printing a header string, use a value of "".  */
   const char *header;
+
+  /* Flags for this child.  */
+  int flags;
 
   /* Where to group the child options relative to the other ("consolidated")
      options in the parent argp; the values are the same as the GROUP field

--- a/lib/clean-temp-private.h
+++ b/lib/clean-temp-private.h
@@ -58,10 +58,10 @@ struct closeable_fd
 {
   /* The file descriptor to close.  */
   int volatile fd;
-  /* Set to true when it has been closed.  */
-  bool volatile closed;
   /* Lock that protects the fd from being closed twice.  */
   asyncsafe_spinlock_t lock;
+  /* Set to true when it has been closed.  */
+  bool volatile closed;
   /* Tells whether this list element has been done and can be freed.  */
   bool volatile done;
 };

--- a/lib/dfa.c
+++ b/lib/dfa.c
@@ -404,10 +404,10 @@ enum { MAX_TRCOUNT = 1024 };
 struct mb_char_classes
 {
   ptrdiff_t cset;
-  bool invert;
   char32_t *chars;              /* Normal characters.  */
   idx_t nchars;
   idx_t nchars_alloc;
+  bool invert;
 };
 
 struct regex_syntax
@@ -443,6 +443,9 @@ struct regex_syntax
    meaning of the @#%!@#%^!@ syntax bits.  */
 struct lexer_state
 {
+  /* The most recently analyzed multibyte bracket expression.  */
+  struct mb_char_classes brack;
+
   char const *ptr;	/* Pointer to next input character.  */
   idx_t left;		/* Number of characters remaining.  */
   token lasttok;	/* Previous token returned; initially END.  */
@@ -453,9 +456,6 @@ struct lexer_state
      or WEOF if there was an encoding error.  Used only if
      MB_CUR_MAX > 1.  */
   wint_t wctok;
-
-  /* The most recently analyzed multibyte bracket expression.  */
-  struct mb_char_classes brack;
 
   /* We're separated from beginning or (, | only by zero-width characters.  */
   bool laststart;

--- a/lib/getopt-ext.h
+++ b/lib/getopt-ext.h
@@ -52,8 +52,8 @@ struct option
   const char *name;
   /* has_arg can't be an enum because some compilers complain about
      type mismatches in all the code that assumes it is an int.  */
-  int has_arg;
   int *flag;
+  int has_arg;
   int val;
 };
 

--- a/lib/getopt_int.h
+++ b/lib/getopt_int.h
@@ -70,9 +70,6 @@ struct _getopt_data
 
   /* Internal members.  */
 
-  /* True if the internal members have been initialized.  */
-  int __initialized;
-
   /* The next char to be scanned in the option-element
      in which the last option character we returned was found.
      This allows us to pick up the scan where we left off.
@@ -80,6 +77,9 @@ struct _getopt_data
      If this is zero, or a null string, it means resume the scan
      by advancing to the next ARGV-element.  */
   char *__nextchar;
+
+  /* True if the internal members have been initialized.  */
+  int __initialized;
 
   /* See __ord above.  */
   enum __ord __ordering;

--- a/lib/git-merge-changelog.c
+++ b/lib/git-merge-changelog.c
@@ -979,10 +979,10 @@ conflict_write (FILE *fp, struct conflict *c)
 /* Long options.  */
 static const struct option long_options[] =
 {
-  { "help", no_argument, NULL, 'h' },
-  { "split-merged-entry", no_argument, NULL, CHAR_MAX + 1 },
-  { "version", no_argument, NULL, 'V' },
-  { NULL, 0, NULL, 0 }
+  { "help", NULL, no_argument, 'h' },
+  { "split-merged-entry", NULL, no_argument, CHAR_MAX + 1 },
+  { "version", NULL, no_argument, 'V' },
+  { NULL, NULL, 0, 0 }
 };
 
 /* Print a usage message and exit.  */

--- a/lib/long-options.c
+++ b/lib/long-options.c
@@ -33,9 +33,9 @@
 
 static struct option const long_options[] =
 {
-  {"help", no_argument, NULL, 'h'},
-  {"version", no_argument, NULL, 'v'},
-  {NULL, 0, NULL, 0}
+  {"help", NULL, no_argument, 'h'},
+  {"version", NULL, no_argument, 'v'},
+  {NULL, NULL, 0, 0}
 };
 
 /* Process long options --help and --version, but only if argc == 2.

--- a/lib/printf-parse.h
+++ b/lib/printf-parse.h
@@ -54,15 +54,15 @@ typedef struct
 {
   const char* dir_start;
   const char* dir_end;
-  int flags;
   const char* width_start;
   const char* width_end;
   size_t width_arg_index;
   const char* precision_start;
   const char* precision_end;
   size_t precision_arg_index;
-  char conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
   size_t arg_index;
+  int flags;
+  char conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
 }
 char_directive;
 
@@ -84,15 +84,15 @@ typedef struct
 {
   const uint8_t* dir_start;
   const uint8_t* dir_end;
-  int flags;
   const uint8_t* width_start;
   const uint8_t* width_end;
   size_t width_arg_index;
   const uint8_t* precision_start;
   const uint8_t* precision_end;
   size_t precision_arg_index;
-  uint8_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
   size_t arg_index;
+  int flags;
+  uint8_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
 }
 u8_directive;
 
@@ -112,15 +112,15 @@ typedef struct
 {
   const uint16_t* dir_start;
   const uint16_t* dir_end;
-  int flags;
   const uint16_t* width_start;
   const uint16_t* width_end;
   size_t width_arg_index;
   const uint16_t* precision_start;
   const uint16_t* precision_end;
   size_t precision_arg_index;
-  uint16_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
   size_t arg_index;
+  int flags;
+  uint16_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
 }
 u16_directive;
 
@@ -140,15 +140,15 @@ typedef struct
 {
   const uint32_t* dir_start;
   const uint32_t* dir_end;
-  int flags;
   const uint32_t* width_start;
   const uint32_t* width_end;
   size_t width_arg_index;
   const uint32_t* precision_start;
   const uint32_t* precision_end;
   size_t precision_arg_index;
-  uint32_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
   size_t arg_index;
+  int flags;
+  uint32_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
 }
 u32_directive;
 

--- a/lib/stackvma.c
+++ b/lib/stackvma.c
@@ -141,13 +141,13 @@ struct rofile
   {
     size_t position;
     size_t filled;
-    int eof_seen;
     /* These fields deal with allocation of the buffer.  */
     char *buffer;
     char *auxmap;
     size_t auxmap_length;
     uintptr_t auxmap_start;
     uintptr_t auxmap_end;
+    int eof_seen;
     char stack_allocated_buffer[STACK_ALLOCATED_BUFFER_SIZE];
   };
 

--- a/lib/uniname/uninames.h
+++ b/lib/uniname/uninames.h
@@ -134631,7 +134631,7 @@ static const struct { uint16_t index; uint32_t name:24; } ATTRIBUTE_PACKED unico
 };
 #define UNICODE_CHARNAME_MAX_LENGTH 88
 #define UNICODE_CHARNAME_MAX_WORDS 15
-static const struct { uint16_t index; uint32_t gap; uint16_t length; } unicode_ranges[721] = {
+static const struct { uint16_t index; uint32_t gap; uint16_t length; } ATTRIBUTE_PACKED unicode_ranges[721] = {
   { 0, 32, 95 },
   { 95, 65, 728 },
   { 823, 67, 6 },

--- a/lib/vma-iter.c
+++ b/lib/vma-iter.c
@@ -165,13 +165,13 @@ struct rofile
   {
     size_t position;
     size_t filled;
-    int eof_seen;
     /* These fields deal with allocation of the buffer.  */
     char *buffer;
     char *auxmap;
     size_t auxmap_length;
     unsigned long auxmap_start;
     unsigned long auxmap_end;
+    int eof_seen;
     char stack_allocated_buffer[STACK_ALLOCATED_BUFFER_SIZE];
   };
 

--- a/lib/wprintf-parse.h
+++ b/lib/wprintf-parse.h
@@ -48,15 +48,15 @@ typedef struct
 {
   const wchar_t* dir_start;
   const wchar_t* dir_end;
-  int flags;
   const wchar_t* width_start;
   const wchar_t* width_end;
   size_t width_arg_index;
   const wchar_t* precision_start;
   const wchar_t* precision_end;
   size_t precision_arg_index;
-  wchar_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
   size_t arg_index;
+  int flags;
+  wchar_t conversion; /* d i b B o u x X f F e E g G a A c s p n U % but not C S */
 }
 wchar_t_directive;
 


### PR DESCRIPTION
@bhaible,
Smaller size structure or class, higher chance putting into cpu cache, changes require checking using yours benchmark, I haven't figured out how to run bench in your project yet.

Most processors are already 64 bit, so the change won't make it any worse.

Info about technique:

https://stackoverflow.com/a/20882083
https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/
https://en.wikipedia.org/wiki/Data_structure_alignment

Affected structs:
- u16_directive 88 -> 80 bytes
- rofile 72 -> 64 bytes
- option 32 -> 24 bytes
- _getopt_data 56 -> 48 bytes
- wchar_t_directive 88 -> 80 bytes
- unicode_ranges 12 -> 8 bytes
- lexer_state 96 -> 88 bytes
- char_directive 88 -> 80 bytes
- hol_entry 56 -> 48 bytes
- argp_option 48 -> 40 bytes
- argp_child 32 -> 24 bytes
- u8_directive 88 -> 80 bytes
- closeable_fd 16 -> 12 bytes
- u32_directive 88 -> 80 bytes