### PR TITLE
Fix: ill-defined _UCRT for mingw64

### DIFF
--- a/lib/vasnprintf.c
+++ b/lib/vasnprintf.c
@@ -228,7 +228,7 @@
 # if ((HAVE_SNPRINTF || HAVE_DECL__SNPRINTF) \
       && (2 <= __GLIBC__ || __ANDROID__ || MUSL_LIBC \
           || __FreeBSD__ || __DragonFly__ || __NetBSD__ || __OpenBSD__ \
-          || (__APPLE__ && __MACH__) || _UCRT))
+          || (__APPLE__ && __MACH__) || defined(_UCRT)))
 #  define USE_SNPRINTF 1
 # else
 #  define USE_SNPRINTF 0


### PR DESCRIPTION
https://github.com/coreutils/gnulib/commit/08c8a9228ffce55e2e18e9ef74f3e98cc869511e
```
vasnprintf.c:233:46: error: operator '||' has no right operand
  233 |           || (__APPLE__ && __MACH__) || _UCRT))
      |                                              ^
```